### PR TITLE
Branch 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ What the pro add-on you get these additional features:
 * Use post title as alt text. If image is not attached to a post, image filename will be used instead.
 * Use post title as caption. If image is not attached to a post, image filename will be used instead.
 * Use post title as description. If image is not attached to a post, image filename will be used instead.
-* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%yoastfocuskw%`, `%rankmathfocuskw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
+* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%category%`, `%tag%`, `%yoastfocuskw%`, `%rankmathfocuskw%`, `%seopresstargetkw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
 * Use Yoast Focus Keyword and Rank Math Focus Keyword as image attributes.
 * Clear any image attribute by setting it as blank / empty. 
 * Exclude images from Bulk Updater. A meta box and a checkbox is added to the `Media Library` > `Edit Media` sidebar. When checked, the bulk updater will not update the attributes of that image in the media library or in posts / products where the image is used.
@@ -68,7 +68,7 @@ What the pro add-on you get these additional features:
 * Clean the actual image filename after upload.
 * Choose to turn off any of the above mentioned features.
 
-With the pro bulk updater you can:
+With the Image Attributes Pro bulk updater you can:
 
 * Update image title and alt text for images inserted into posts and custom post types. Not just the media library. [What is the difference?](https://imageattributespro.com/how-wordpress-store-image-attributes/?utm_source=github&utm_medium=readme.md)
 * Fine tune all settings. Choose what to update.
@@ -76,12 +76,17 @@ With the pro bulk updater you can:
 * Update image titles / alt text in media library and existing posts.
 * Update image titles / alt text in media library and existing posts only if no title / alt text is set. Existing image titles / alt text will not be changed.
 * Update image caption and description in the media library. Existing image captions and descriptions can be preserved.
-* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%yoastfocuskw%`, `%rankmathfocuskw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
+* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%category%`, `%tag%`, `%yoastfocuskw%`, `%rankmathfocuskw%`, `%seopresstargetkw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
 * Choose to turn off any of the above mentioned features.
 * Modify auto generated image attributes using the [iaffpro_image_attributes filter](https://imageattributespro.com/codex/iaffpro_image_attributes/?utm_source=github&utm_medium=readme.md).
 * Choose specific post types to bulk update using the [iaffpro_included_post_types filter](https://imageattributespro.com/codex/iaffpro_included_post_types/?utm_source=github&utm_medium=readme.md).
 * Disable updating of attributes in media library completely using the [iaffpro_update_media_library filter](https://imageattributespro.com/codex/iaffpro_update_media_library/?utm_source=github&utm_medium=readme.md).
 * Add or remove custom image attributes using the [iaffpro_html_image_markup_post_update filter](https://imageattributespro.com/codex/iaffpro_html_image_markup_post_update/?utm_source=github&utm_medium=readme.md)
+
+Other Image Attributes Pro features:
+
+* Bulk Update image attributes from WordPress Media Library. Select images and choose `Update image attributes` Bulk action in Media Library (list view). [Read more.](https://imageattributespro.com/bulk-actions/?utm_source=github&utm_medium=readme.md)
+* Bulk Update image attributes from WordPress admin page for Posts, Pages and WooCommerce Products. Select the posts, pages or WooCommerce products in bulk and choose "Update image attributes" Bulk action. [Read more.](https://imageattributespro.com/bulk-actions/?utm_source=github&utm_medium=readme.md)
 
 For screenshots, FAQ and further details, please see the [product website](https://imageattributespro.com/?utm_source=github&utm_medium=readme.md).
 

--- a/admin/iaff_image-attributes-from-filename-admin-setup.php
+++ b/admin/iaff_image-attributes-from-filename-admin-setup.php
@@ -275,14 +275,14 @@ function iaff_settings_validater_and_sanitizer( $settings ) {
 	$settings['bu_custom_filter']	= sanitize_text_field( $settings['bu_custom_filter'] );
 	
 	// Sanitize Custom Attributes
-	$settings['custom_attribute_title'] 		= sanitize_text_field( $settings['custom_attribute_title'] );
-	$settings['custom_attribute_bu_title'] 		= sanitize_text_field( $settings['custom_attribute_bu_title'] );
-	$settings['custom_attribute_alt_text'] 		= sanitize_text_field( $settings['custom_attribute_alt_text'] );
-	$settings['custom_attribute_bu_alt_text'] 	= sanitize_text_field( $settings['custom_attribute_bu_alt_text'] );
-	$settings['custom_attribute_caption'] 		= sanitize_text_field( $settings['custom_attribute_caption'] );
-	$settings['custom_attribute_bu_caption'] 	= sanitize_text_field( $settings['custom_attribute_bu_caption'] );
-	$settings['custom_attribute_description'] 	= sanitize_text_field( $settings['custom_attribute_description'] );
-	$settings['custom_attribute_bu_description'] 	= sanitize_text_field( $settings['custom_attribute_bu_description'] );
+	$settings['custom_attribute_title'] 			= iaff_sanitize_text_field( $settings['custom_attribute_title'] );
+	$settings['custom_attribute_bu_title'] 			= iaff_sanitize_text_field( $settings['custom_attribute_bu_title'] );
+	$settings['custom_attribute_alt_text'] 			= iaff_sanitize_text_field( $settings['custom_attribute_alt_text'] );
+	$settings['custom_attribute_bu_alt_text'] 		= iaff_sanitize_text_field( $settings['custom_attribute_bu_alt_text'] );
+	$settings['custom_attribute_caption'] 			= iaff_sanitize_text_field( $settings['custom_attribute_caption'] );
+	$settings['custom_attribute_bu_caption'] 		= iaff_sanitize_text_field( $settings['custom_attribute_bu_caption'] );
+	$settings['custom_attribute_description'] 		= iaff_sanitize_text_field( $settings['custom_attribute_description'] );
+	$settings['custom_attribute_bu_description'] 	= iaff_sanitize_text_field( $settings['custom_attribute_bu_description'] );
 	
 	// Validating Regex
 	if( @preg_match( $settings['regex_filter'], null ) === false ) {
@@ -295,6 +295,28 @@ function iaff_settings_validater_and_sanitizer( $settings ) {
 	}
 	
 	return $settings;
+}
+
+/**
+ * Extend sanitize_text_field() to preserve %category% custom attribute tag.
+ * 
+ * sanitize_text_field() converts %category% to tegory%.
+ * Here %category% is replaced with IAFF_CATEGORY_CUSTOM_TAG keyword before sanitization. 
+ * Then IAFF_CATEGORY_CUSTOM_TAG is replaced with %category% after sanitization. 
+ * 
+ * @since 3.1
+ * 
+ * @param (String) $str String to be sanitized.
+ * 
+ * @return (String) Sanitized string with %category% preserved. 
+ */
+function iaff_sanitize_text_field( $str ) {
+
+	$str = str_replace( '%category%', 'IAFF_CATEGORY_CUSTOM_TAG', $str );
+	$str = sanitize_text_field( $str );
+	$str = str_replace( 'IAFF_CATEGORY_CUSTOM_TAG', '%category%', $str );
+
+	return $str;
 }
 
 /**
@@ -379,6 +401,8 @@ function iaff_custom_attribute_tags() {
 		'filename'		=> __( 'Image filename', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'posttitle'		=> __( 'Title of the post, page or product where the image is used', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'sitetitle'		=> __( 'Site Title defined in WordPress General Settings', 'auto-image-attributes-from-filename-with-bulk-updater' ),
+		'category'		=> __( 'Post or Product Category', 'auto-image-attributes-from-filename-with-bulk-updater' ),
+		'tag'			=> __( 'Post or Product Tag', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'yoastfocuskw'		=> __( 'Yoast Focus Keyword', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'rankmathfocuskw'	=> __( 'Rank Math Focus Keyword', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 	);

--- a/admin/iaff_image-attributes-from-filename-admin-setup.php
+++ b/admin/iaff_image-attributes-from-filename-admin-setup.php
@@ -403,9 +403,15 @@ function iaff_custom_attribute_tags() {
 		'sitetitle'		=> __( 'Site Title defined in WordPress General Settings', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'category'		=> __( 'Post or Product Category', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 		'tag'			=> __( 'Post or Product Tag', 'auto-image-attributes-from-filename-with-bulk-updater' ),
-		'yoastfocuskw'		=> __( 'Yoast Focus Keyword', 'auto-image-attributes-from-filename-with-bulk-updater' ),
-		'rankmathfocuskw'	=> __( 'Rank Math Focus Keyword', 'auto-image-attributes-from-filename-with-bulk-updater' ),
 	);
 	
-	return $available_tags;
+	/**
+	 * Filter the custom attribute tags. 
+	 * Used by Image Attributes Pro to add custom tags like %yoastfocuskw% and %rankmathfocuskw% dynamically. 
+	 * 
+	 * @since 3.1
+	 * 
+	 * @param $available_tags (array) Array containing all custom attribute tags.
+	 */
+	return apply_filters( 'iaff_custom_attribute_tags', $available_tags );
 }

--- a/admin/iaff_image-attributes-from-filename-admin-ui-render.php
+++ b/admin/iaff_image-attributes-from-filename-admin-ui-render.php
@@ -1054,12 +1054,16 @@ function iaff_admin_interface_render () {
 					
 					<p><?php _e('To restart processing images from the beginning (the oldest upload first), reset the counter.', 'auto-image-attributes-from-filename-with-bulk-updater') ?></p>
 
-					<p><?php printf( __( 'If Bulk Updater is stuck, refresh the page, skip current image and try running the bulk updater again. <a href="%s" target="_blank">Read more.</a>', 'auto-image-attributes-from-filename-with-bulk-updater' ), 'https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=iaff-basic&utm_medium=skip-image-button' ); ?></p>
+					<?php if ( apply_filters( 'iaff_debug_mode', false ) ) { ?>
+						<p><?php printf( __( 'If Bulk Updater is stuck, refresh the page, skip current image and try running the bulk updater again. <a href="%s" target="_blank">Read more.</a>', 'auto-image-attributes-from-filename-with-bulk-updater' ), 'https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=iaff-basic&utm_medium=skip-image-button' ); ?></p>
+					<?php } ?>
 
 					<p class="submit">
 						<input class="button-secondary iaff-bulk-updater-buttons iaff_reset_counter_button" type="submit" name="Reset Counter" value="<?php _e( 'Reset Counter', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" />
 						
-						<input class="button-secondary iaff-bulk-updater-buttons iaff_skip_image_button" type="submit" name="Skip Image" value="<?php _e( 'Skip Image', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" />
+						<?php if ( apply_filters( 'iaff_debug_mode', false ) ) { ?>
+							<input class="button-secondary iaff-bulk-updater-buttons iaff_skip_image_button" type="submit" name="Skip Image" value="<?php _e( 'Skip Image', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" />
+						<?php } ?>
 					</p>
 					
 					<!-- Event log -->

--- a/admin/iaff_image-attributes-from-filename-admin-ui-render.php
+++ b/admin/iaff_image-attributes-from-filename-admin-ui-render.php
@@ -1050,13 +1050,17 @@ function iaff_admin_interface_render () {
 						<input class="button-secondary iaff-bulk-updater-buttons iaff_stop_bulk_updater_button" type="submit" name="Stop Bulk Updater" value="<?php _e( 'Stop Bulk Updater', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" disabled />
 					</p>
 					
-					<h2 class="showh2"><?php _e('Reset Counter', 'auto-image-attributes-from-filename-with-bulk-updater') ?></h2>
+					<h2 class="showh2"><?php _e('Tools', 'auto-image-attributes-from-filename-with-bulk-updater') ?></h2>
 					
-					<p><?php _e('To restart processing images from the beginning (the oldest upload first), reset the counter.', 'auto-image-attributes-from-filename-with-bulk-updater') ?></p> 
-					
-					<span class="reset-counter-button">
-						<?php submit_button( __('Reset Counter', 'auto-image-attributes-from-filename-with-bulk-updater'), 'iaff_reset_counter_button' ); ?>
-					</span>
+					<p><?php _e('To restart processing images from the beginning (the oldest upload first), reset the counter.', 'auto-image-attributes-from-filename-with-bulk-updater') ?></p>
+
+					<p><?php printf( __( 'If Bulk Updater is stuck, refresh the page, skip current image and try running the bulk updater again. <a href="%s" target="_blank">Read more.</a>', 'auto-image-attributes-from-filename-with-bulk-updater' ), 'https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=iaff-basic&utm_medium=skip-image-button' ); ?></p>
+
+					<p class="submit">
+						<input class="button-secondary iaff-bulk-updater-buttons iaff_reset_counter_button" type="submit" name="Reset Counter" value="<?php _e( 'Reset Counter', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" />
+						
+						<input class="button-secondary iaff-bulk-updater-buttons iaff_skip_image_button" type="submit" name="Skip Image" value="<?php _e( 'Skip Image', 'auto-image-attributes-from-filename-with-bulk-updater' ) ?>" />
+					</p>
 					
 					<!-- Event log -->
 					<div id="bulk-updater-results">

--- a/admin/iaff_image-attributes-from-filename-do.php
+++ b/admin/iaff_image-attributes-from-filename-do.php
@@ -192,6 +192,11 @@ function iaff_before_bulk_updater() {
 	// Security Check
 	check_ajax_referer( 'iaff_before_bulk_updater_nonce', 'security' );
 	
+	/**
+	 * Action hook that is fired at the start of the Bulk Updater before updating any image.
+	 * 
+	 * @link https://imageattributespro.com/codex/iaff_before_bulk_updater/
+	 */
 	do_action('iaff_before_bulk_updater');
 }
 add_action( 'wp_ajax_iaff_before_bulk_updater', 'iaff_before_bulk_updater' );
@@ -206,6 +211,11 @@ function iaff_after_bulk_updater() {
 	// Security Check
 	check_ajax_referer( 'iaff_after_bulk_updater_nonce', 'security' );
 	
+	/**
+	 * Action hook that is fired at the end of the Bulk Updater after updating all images.
+	 * 
+	 * @link https://imageattributespro.com/codex/iaff_after_bulk_updater/
+	 */
 	do_action('iaff_after_bulk_updater');
 }
 add_action( 'wp_ajax_iaff_after_bulk_updater', 'iaff_after_bulk_updater');

--- a/admin/iaff_image-attributes-from-filename-do.php
+++ b/admin/iaff_image-attributes-from-filename-do.php
@@ -81,9 +81,12 @@ function iaff_rename_old_image() {
 	
 	// Image Attributes Pro
 	if ( iaff_is_pro() ) {
+
+		// Get the object of the image form image ID.
+		$image_object = get_post( $image->ID );
 		
 		// Running the pro module
-		iaffpro_auto_image_attributes_pro($image, true);
+		iaffpro_auto_image_attributes_pro( $image_object, true );
 		
 	} else {
 		

--- a/admin/iaff_image-attributes-from-filename-do.php
+++ b/admin/iaff_image-attributes-from-filename-do.php
@@ -211,6 +211,32 @@ function iaff_after_bulk_updater() {
 add_action( 'wp_ajax_iaff_after_bulk_updater', 'iaff_after_bulk_updater');
 
 /**
+ * Increment the counter by one to skip one image.
+ * 
+ * @since 3.1
+ */
+function iaff_bulk_updater_skip_image() {
+	
+	// Security Check
+	check_ajax_referer( 'iaff_bulk_updater_skip_image_nonce', 'security' );
+	
+	// Retrieve Counter
+	$counter = get_option( 'iaff_bulk_updater_counter' );
+	$counter = intval ( $counter );
+
+	// Increment counter and update it
+	$counter++;
+	update_option( 'iaff_bulk_updater_counter', $counter );
+	
+	$response = array(
+		'message'			=> __( 'One image skipped.', 'auto-image-attributes-from-filename-with-bulk-updater' ),
+		'remaining_images'	=> iaff_count_remaining_images( true ),
+	);
+	wp_send_json( $response );
+}
+add_action( 'wp_ajax_iaff_bulk_updater_skip_image', 'iaff_bulk_updater_skip_image' );
+
+/**
  * Bulk Updater Ajax
  *
  * @since 1.0
@@ -395,6 +421,21 @@ function iaff_image_bulk_updater() {
 				}
 			});
 			$('#iaff-reset-counter-dialog').dialog('open');
+		});
+
+		// Skip Image Button
+		$('.iaff_skip_image_button').click( function() {
+			
+			data = {
+				action: 'iaff_bulk_updater_skip_image',
+				security: '<?php echo wp_create_nonce( "iaff_bulk_updater_skip_image_nonce" ); ?>'
+			};
+
+			$.post(ajaxurl, data, function (response) {
+				$('#bulk-updater-log').append('<p class="iaff-green"><span class="dashicons dashicons-yes"></span>' + response.message + '</p>');
+				$('#bulk-updater-log').append('<p>Number of Images Remaining: ' + response.remaining_images + '</p>');
+				$("#bulk-updater-log").animate({scrollTop:$("#bulk-updater-log")[0].scrollHeight - $("#bulk-updater-log").height()},200);
+			});
 		});
 		
 	});	

--- a/iaff_image-attributes-from-filename.php
+++ b/iaff_image-attributes-from-filename.php
@@ -5,7 +5,7 @@
  * Description: Automatically Add Image Title, Image Caption, Description And Alt Text From Image Filename. Since this plugin includes a bulk updater this can update both existing images in the Media Library and new images. 
  * Author: Arun Basil Lal
  * Author URI: https://imageattributespro.com/?utm_source=plugin-header&utm_medium=author-uri
- * Version: 3.0
+ * Version: 3.1
  * Text Domain: auto-image-attributes-from-filename-with-bulk-updater
  * Domain Path: /languages
  * License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -67,7 +67,7 @@ if ( ! defined( 'IAFF_IMAGE_ATTRIBUTES_FROM_FILENAME_URL' ) ) {
  * @since 1.3
  */
 if ( ! defined( 'IAFF_VERSION_NUM' ) ) {
-	define( 'IAFF_VERSION_NUM', '3.0' );
+	define( 'IAFF_VERSION_NUM', '3.1' );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ The pro add-on can update the image attributes from not just the image filename,
 * Use post title as alt text. If image is not attached to a post, image filename will be used instead.
 * Use post title as caption. If image is not attached to a post, image filename will be used instead.
 * Use post title as description. If image is not attached to a post, image filename will be used instead.
-* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%yoastfocuskw%`, `%rankmathfocuskw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
+* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%category%`, `%tag%`, `%yoastfocuskw%`, `%rankmathfocuskw%`, `%seopresstargetkw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
 * Use Yoast Focus Keyword and Rank Math Focus Keyword as image attributes.
 * Clear any image attribute by setting it as blank / empty. 
 * Exclude images from Bulk Updater. A meta box and a checkbox is added to the `Media Library` > `Edit Media` sidebar. When checked, the bulk updater will not update the attributes of that image in the media library or in posts / products where the image is used. 
@@ -92,7 +92,7 @@ The pro add-on can update the image attributes from not just the image filename,
 * Clean the actual image filename after upload.
 * Choose to turn off any of the above mentioned features.
 
-**With the pro bulk updater you can:**
+**With the Image Attributes Pro bulk updater you can:**
 
 * Update image title and alt text **for images inserted into posts and custom post types**. Not just the media library. [What is the difference?](https://imageattributespro.com/how-wordpress-store-image-attributes/?utm_source=wordpress.org&utm_medium=readme)
 * Fine tune all settings. Choose what to update.
@@ -100,12 +100,17 @@ The pro add-on can update the image attributes from not just the image filename,
 * Update image titles / alt text in media library and existing posts.
 * Update image titles / alt text in media library and existing posts only if no title / alt text is set. Existing image titles / alt text will not be changed.
 * Update image caption and description in the media library. Existing image captions and descriptions can be preserved.
-* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%yoastfocuskw%`, `%rankmathfocuskw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
+* Build your own attributes using custom tags like `%filename%`, `%posttitle%`, `%sitetitle%`, `%category%`, `%tag%`, `%yoastfocuskw%`, `%rankmathfocuskw%`, `%seopresstargetkw%`. Each custom tag will be replaced  with it's value. You can combine them as you please!
 * Choose to turn off any of the above mentioned features.
 * Modify auto generated image attributes using the [iaffpro_image_attributes filter](https://imageattributespro.com/codex/iaffpro_image_attributes/?utm_source=wordpress.org&utm_medium=readme).
 * Choose specific post types to bulk update using the [iaffpro_included_post_types filter](https://imageattributespro.com/codex/iaffpro_included_post_types/?utm_source=wordpress.org&utm_medium=readme).
 * Disable updating of attributes in media library completely using the [iaffpro_update_media_library filter](https://imageattributespro.com/codex/iaffpro_update_media_library/?utm_source=wordpress.org&utm_medium=readme).
 * Add or remove custom image attributes using the [iaffpro_html_image_markup_post_update filter](https://imageattributespro.com/codex/iaffpro_html_image_markup_post_update/?utm_source=wordpress.org&utm_medium=readme)
+
+**Other Image Attributes Pro features:**
+
+* Bulk Update image attributes from WordPress Media Library. Select images and choose `Update image attributes` Bulk action in Media Library (list view). [Read more.](https://imageattributespro.com/bulk-actions/?utm_source=wordpress.org&utm_medium=readme)
+* Bulk Update image attributes from WordPress admin page for Posts, Pages and WooCommerce Products. Select the posts, pages or WooCommerce products in bulk and choose "Update image attributes" Bulk action. [Read more.](https://imageattributespro.com/bulk-actions/?utm_source=wordpress.org&utm_medium=readme)
 
 For screenshots, FAQ and full list of features, please see the [product website](https://imageattributespro.com/?utm_source=wordpress.org&utm_medium=readme).
 
@@ -145,43 +150,43 @@ I am glad to hear that! You can either [upgrade to pro](https://imageattributesp
 == Changelog ==
 
 = 3.1 =
-* Date: 
+* Date: 24.March.2022.
 * Tested with WordPress 5.9.2.
-* Enhancement: Added 'Skip Image' button for the Bulk Updater. Useful during troubleshooting. [Read more.](https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=wordpress.org&utm_medium=changelog)
-* Enhancement: Compatibility with Image Attributes Pro version 3.0. [Image Attributes Pro changelog.](https://imageattributespro.com/changelog/?utm_source=wordpress.org&utm_medium=changelog)
+* New Feature: Added 'Skip Image' button for the Bulk Updater. Useful during troubleshooting. [Read more.](https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=wordpress.org&utm_medium=changelog)
+* Enhancement: Compatibility with Image Attributes Pro version 3.0. [Check what's new in 3.0.](https://imageattributespro.com/changelog/?utm_source=wordpress.org&utm_medium=changelog)
 
 = 3.0 =
-* Date: 19.January.2022
+* Date: 19.January.2022.
 * Tested with WordPress 5.8.3.
 * Enhancement: Removed "Global Switch" option as part of cleaning up the user interface. This option was redundant and the same can be accomplished either by deactivating the plugin or by disabling every option in "General Settings". Please take a note of this change if you have disabled "Global Switch" on your website.
 * UI Enhancement: Added description text to clarity settings to improve usability. 
 * UI Enhancement: Added [demo video link](https://imageattributespro.com/demo/?utm_source=wordpress.org&utm_medium=changelog) in plugin settings page. 
 
 = 2.1 =
-* Date: 02.July.2021
+* Date: 02.July.2021.
 * Enhancement: Compatibility with Image Attributes Pro v2.0. 
 
 = 2.0 =
-* Date: 18.June.2021
+* Date: 18.June.2021.
 * Tested with WordPress 5.7.2.
 * UI Enhancement: Changed order of `General Settings` to match the order in `Media Library`. 
 * UI Enhancement: Changed the word `attached` to `uploaded` in `If image is not attached to a post, image filename will be used instead` for better clarity. 
 * I18n: More strings are now translation ready, thanks to [@alexclassroom](https://profiles.wordpress.org/alexclassroom/).
 
 = 1.6 =
-* Date: 06.January.2019 
+* Date: 06.January.2019.
 * Tested with WordPress 5.0.2. 
 * Enhancement: Improved bulk updater warning and inline documentation. 
 * Bug Fix: Fixed a bug that ignored the setting for inserting image title into the post HTML. Thanks [@jamesryancooper](https://wordpress.org/support/topic/image-title-being-inserted-even-with-checkbox-unselected/)
 
 = 1.5 =
-* Date: 06.May.2018
+* Date: 06.May.2018.
 * Enhancement: Changed text domain from abl_iaff_td to auto-image-attributes-from-filename-with-bulk-updater to make the plugin translation ready in translate.wordpress.org.
 * Enhancement: Code improvements.
 * Enhancement: Added an activation notice with link to the settings page for better on-boarding experience. 
 
 = 1.4 =
-* Date: 22.November.2017
+* Date: 22.November.2017.
 * NEW: Global switch to enable or disable the plugin.
 * NEW: Test button.
 * NEW: Stop Bulk Updater button.
@@ -194,7 +199,7 @@ I am glad to hear that! You can either [upgrade to pro](https://imageattributesp
 * Code improvements.
 
 = 1.3 =
-* Date: 17.August.2017
+* Date: 17.August.2017.
 * Improved the architecture of the plugin laying foundation for future updates. Utilizing my [starter plugin framework](http://millionclues.com/lab/wordpress-starter-plugin-a-framework-for-quick-plugin-development/)
 * Bug fix: For images that had EXIF data, EXIF data was used instead of filename. Props to @mathieupellegrin for reporting this. 
 * NEW: Added option to Insert Image Title into HTML. WordPress stopped including image titles since 3.5. Code from [Restore Image Title](https://wordpress.org/plugins/restore-image-title/) plugin was used. 
@@ -208,29 +213,35 @@ I am glad to hear that! You can either [upgrade to pro](https://imageattributesp
 * Tested on WordPress 4.8.1. Result = pass.
 
 = 1.2 =
-* Date: 15.July.2017
+* Date: 15.July.2017.
 * Added: Character filter options. Plugin now removes hyphens and underscores.
 * Bug Fix: Minor bug fix.
 
 = 1.1 =
-* Date: 4.July.2017
+* Date: 4.July.2017.
 * Added: Options to choose individual image attributes for NEW uploads. 
 
 = 1.0 =
-* Date: 4.July.2017
+* Date: 4.July.2017.
 * First release of the plugin.
 
 == Upgrade Notice ==
 
+= 3.1 =
+* Date: 24.March.2022. 
+* Tested with WordPress 5.9.2. 
+* New Feature: Added 'Skip Image' button for the Bulk Updater. Useful during troubleshooting. [Read more.](https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=wordpress.org&utm_medium=changelog) 
+* Enhancement: Compatibility with Image Attributes Pro version 3.0. [Check what's new in 3.0.](https://imageattributespro.com/changelog/?utm_source=wordpress.org&utm_medium=changelog)
+
 = 3.0 =
-* Date: 19.January.2022
+* Date: 19.January.2022.
 * Tested with WordPress 5.8.3.
 * Enhancement: Removed "Global Switch" option as part of cleaning up the user interface. This option was redundant and the same can be accomplished either by deactivating the plugin or by disabling every option in "General Settings". Please take a note of this change if you have disabled "Global Switch" on your website.
 * UI Enhancement: Added description text to clarity settings to improve usability. 
 * UI Enhancement: Added [demo video link](https://imageattributespro.com/demo/?utm_source=wordpress.org&utm_medium=changelog) in plugin settings page. 
 
 = 2.1 =
-* Date: 02.July.2021
+* Date: 02.July.2021.
 * Enhancement: Compatibility with Image Attributes Pro v2.0. 
 
 = 2.0 =
@@ -250,7 +261,7 @@ I am glad to hear that! You can either [upgrade to pro](https://imageattributesp
 * Enhancement: Added an activation notice with link to the settings page for better on-boarding experience. 
 
 = 1.4 =
-* Date: 22.November.2017
+* Date: 22.November.2017.
 * NEW: Global switch to enable or disable the plugin.
 * NEW: Test button.
 * NEW: Stop Bulk Updater button.

--- a/readme.txt
+++ b/readme.txt
@@ -144,6 +144,12 @@ I am glad to hear that! You can either [upgrade to pro](https://imageattributesp
 
 == Changelog ==
 
+= 3.1 =
+* Date: 
+* Tested with WordPress 5.9.2.
+* Enhancement: Added 'Skip Image' button for the Bulk Updater. Useful during troubleshooting. [Read more.](https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=wordpress.org&utm_medium=changelog)
+* Enhancement: Compatibility with Image Attributes Pro version 3.0. [Image Attributes Pro changelog.](https://imageattributespro.com/changelog/?utm_source=wordpress.org&utm_medium=changelog)
+
 = 3.0 =
 * Date: 19.January.2022
 * Tested with WordPress 5.8.3.


### PR DESCRIPTION
= 3.1 =
* Date: 24.March.2022.
* Tested with WordPress 5.9.2.
* New Feature: Added 'Skip Image' button for the Bulk Updater. Useful during troubleshooting. [Read more.](https://imageattributespro.com/fix-bulk-updater-stuck-on-same-image/?utm_source=wordpress.org&utm_medium=changelog)
* Enhancement: Compatibility with Image Attributes Pro version 3.0. [Check what's new in 3.0.](https://imageattributespro.com/changelog/?utm_source=wordpress.org&utm_medium=changelog)